### PR TITLE
Update wp_all_import_is_post_to_delete.php

### DIFF
--- a/all-import/wp_all_import_is_post_to_delete.php
+++ b/all-import/wp_all_import_is_post_to_delete.php
@@ -15,7 +15,7 @@
 function my_is_post_to_delete($is_post_to_delete, $post_id, $import)
 {
     // Unless you want this code to execute for every import, check the import id    
-    // if ($import->id === 5) { ... }
+    // if ((int) $import->id === 5) { ... }
     return true;
 }
 


### PR DESCRIPTION
`$import->id` is not integer. It's string, so `===` won't work properly in this case. The solution is to cast `$import->id` to `(int)`